### PR TITLE
Fix object comparison

### DIFF
--- a/lib/elastictastic/basic_document.rb
+++ b/lib/elastictastic/basic_document.rb
@@ -192,7 +192,7 @@ module Elastictastic
     end
 
     def ==(other)
-      index == other.index && id == other.id
+      index == other.index && self.class == other.class && id == other.id
     end
 
     def attributes

--- a/lib/elastictastic/index.rb
+++ b/lib/elastictastic/index.rb
@@ -15,5 +15,9 @@ module Elastictastic
     def to_s
       @name
     end
+
+    def ==(other)
+      name == other.name
+    end
   end
 end

--- a/spec/examples/document_spec.rb
+++ b/spec/examples/document_spec.rb
@@ -659,4 +659,24 @@ describe Elastictastic::Document do
       end
     end
   end
+
+  describe '#==' do
+    it 'should return true if index, id and class of both objects are equal' do
+      first_post = Post.new(index: "post", title: "Hello, world!")
+      first_post.id = 1
+      other_post = Post.new(index: "post", title: "Hello, world!")
+      other_post.id = 1
+
+      other_post.should eq first_post
+    end
+
+    it 'should fail when classes are not equal' do
+      post = Post.new
+      post.id = 1
+      photo = Photo.new
+      photo.id = 1
+
+      photo.should_not eq post
+    end
+  end
 end


### PR DESCRIPTION
Elastictastic was not able to compare two objects that were apparently similar:

```
expected 
    [#<Product id: "1", index: "my_index", name: "Book", ...>]
to include
    #<Product id: "1", index: "my_index", name: "Book", ...>
```

Also, prevents this bug to occur:

```
expected 
    [#<Product id: "1", index: "my_index", name: "Book", ...>]
not to include
    #<User id: "1", index: "my_index", name: "John Dove", ...>
```

I also added two tests to check those behaviours.

Thanks for your work! :)
