### PR TITLE
Show entries on Scope#inspect

### DIFF
--- a/lib/elastictastic/scope.rb
+++ b/lib/elastictastic/scope.rb
@@ -231,7 +231,7 @@ module Elastictastic
     end
 
     def inspect
-      self.entries
+      self.entries.inspect
     end
 
     #


### PR DESCRIPTION
Show all entries from the Enumerable object when inspecting a scope.

See discussion at #27.
