### PR TITLE
Enable hosts in a subpath

### DIFF
--- a/lib/elastictastic/configuration.rb
+++ b/lib/elastictastic/configuration.rb
@@ -70,7 +70,7 @@ module Elastictastic
           :host => url_from_env.host,
           :port => url_from_env.port,
           :path => url_from_env.path
-        )
+        ).to_s
       else
         'http://localhost:9200'
       end


### PR DESCRIPTION
**Work in progress**: This PR enables hosts in a subpath. This is needed when configuring ElasticTastic to work with Heroku ElasticSearch Addons.
