### PR TITLE
Fix Enumerable.new deprecation warnings for Ruby 2.0

### DIFF
--- a/lib/elastictastic.rb
+++ b/lib/elastictastic.rb
@@ -1,6 +1,8 @@
 require 'active_support/core_ext'
 require 'active_model'
 
+require 'elastictastic/enumerable'
+
 require 'elastictastic/adapter'
 require 'elastictastic/basic_document'
 require 'elastictastic/errors'

--- a/lib/elastictastic/enumerable.rb
+++ b/lib/elastictastic/enumerable.rb
@@ -1,0 +1,3 @@
+class EnumerableObject < BasicObject
+  include ::Enumerable
+end

--- a/lib/elastictastic/scope.rb
+++ b/lib/elastictastic/scope.rb
@@ -2,7 +2,7 @@ require 'hashie'
 require 'elastictastic/search'
 
 module Elastictastic
-  class Scope < BasicObject
+  class Scope < EnumerableObject
     attr_reader :clazz, :index
 
     def initialize(index, clazz, search = Search.new, parent = nil, routing = nil)
@@ -22,7 +22,7 @@ module Elastictastic
       if ::Kernel.block_given?
         find_each { |result, hit| yield result }
       else
-        ::Enumerator.new(self, :each)
+        to_enum
       end
     end
 
@@ -417,8 +417,10 @@ module Elastictastic
 
     def materialize_hits(hits)
       unless ::Kernel.block_given?
-        return ::Enumerator.new(self, :materialize_hits, hits)
+        # TODO: This is a hack to avoid using to_enum, which seems to have some subclassing issues (tries to call :materialize_hit on a generic Class)
+        return hits.select { |h| h['exists'] != false }.collect { |h| [materialize_hit(h), ::Hashie::Mash.new(h)] }
       end
+      
       hits.each do |hit|
         unless hit['exists'] == false
           yield materialize_hit(hit), ::Hashie::Mash.new(hit)


### PR DESCRIPTION
Eliminates deprecation warnings when upgrading to Ruby 2.0.

Specs run green on 1.9.3 and 2.0.0.
