### PR TITLE
Don't execute query for Scope.inspect

### DIFF
--- a/lib/elastictastic/scope.rb
+++ b/lib/elastictastic/scope.rb
@@ -263,7 +263,7 @@ module Elastictastic
     end
 
     def inspect
-      self.entries.inspect
+      "#<#{name} id: #{object_id} >"
     end
 
     #


### PR DESCRIPTION
Why:
- To remove unneccessary query to elasticsearch

How:
- Change the return value to not depend on ES result
